### PR TITLE
Apply console context to deprecate warnings

### DIFF
--- a/src/backbone-metal.js
+++ b/src/backbone-metal.js
@@ -443,15 +443,33 @@ deprecate._format = function(prev, next) {
 };
 
 /**
- * A safe reference to `console.warn` that will fallback to `console.log` or
- * `_noop` if the `console` object does not exist.
+ * A safe reference to the console object that will fallback to an empty
+ * object.
+ *
+ * @private
+ * @property _console
+ */
+var _console = typeof console !== 'undefined' ? console : {};
+
+/**
+ * A safe reference to the console.warn method that will fallback a noop.
+ *
+ * @private
+ * @property _warn
+ */
+var _warn = _console.warn || _console.log || _.noop;
+
+/**
+ * A safe reference to `console.warn`.
  *
  * @private
  * @method _warn
  * @memberOf deprecate
  * @param {*...} - The values to warn in the console.
  */
-deprecate._warn = typeof console !== 'undefined' && (console.warn || console.log) || _.noop;
+deprecate._warn = function() {
+  return _warn.apply(_console, arguments);
+};
 
 /**
  * An internal cache to avoid sending the same deprecation warning multiple

--- a/test/deprecate.js
+++ b/test/deprecate.js
@@ -1,9 +1,21 @@
 describe('deprecate', function() {
   beforeEach(function() {
-    stub(Metal.deprecate, '_warn');
+    spy(Metal.deprecate, '_warn');
     Metal.deprecate._cache = {};
   });
 
+  describe('Metal.deprecate._warn', function() {
+    beforeEach(function() {
+      Metal.deprecate._warn('foo');
+    });
+
+    it('should `console.warn` the message', function() {
+      expect(Metal.deprecate._warn)
+        .to.have.been.calledOnce
+        .and.calledWith('foo');
+    });
+  });
+  
   describe('when calling with a message', function() {
     beforeEach(function() {
       Metal.deprecate('foo');

--- a/test/support.js
+++ b/test/support.js
@@ -70,19 +70,23 @@ describe('Support', function() {
 
   describe('when console.warn does not exist', function() {
     beforeEach(function(done) {
-      var prevWarn = console.warn;
-      var prevLog = console.log;
+      this.prevWarn = console.warn;
+      this.prevLog = console.log;
       this.logStub = stub(console, 'log');
       delete console.warn;
       console.warn = undefined;
       update(done);
-      console.warn = prevWarn;
-      console.log = prevLog;
     });
 
     describe('deprecate', function() {
       beforeEach(function() {
         Metal.deprecate('foo');
+        
+        // Metal.deprecate chooses the console function during execution.
+        // console.warn / console.log must be returned to normal to see 
+        // test results.
+        console.warn = this.prevWarn;
+        console.log = this.prevLog;
       });
 
       it('should use console.log instead', function() {


### PR DESCRIPTION
To ensure console compatibility

Resolves #9

Solution from https://github.com/marionettejs/backbone.marionette/pull/2459
